### PR TITLE
Use significantly less CPU by adding a small delay

### DIFF
--- a/chronometer.py
+++ b/chronometer.py
@@ -98,6 +98,8 @@ os.system("clear")
 os.system("setterm -cursor off")
 while True:
     try:
+        time.sleep(0.05);
+
         now = datetime.datetime.now()
         utcnow = datetime.datetime.utcnow()
         if(dbg):


### PR DESCRIPTION
On my desktop system without this change Chronometer consumes ~20% of my CPU. After adding this small delay it drops to 2% CPU usage. This still results in 20x updates per second. I don't notice any visual difference.
